### PR TITLE
Fix: Voicevox互換API経由で生成しようとするとAssertionErrorが出るのを修正

### DIFF
--- a/voicevox_engine/tts_pipeline/style_bert_vits2_tts_engine.py
+++ b/voicevox_engine/tts_pipeline/style_bert_vits2_tts_engine.py
@@ -504,11 +504,8 @@ class StyleBertVITS2TTSEngine(TTSEngine):
             # 読み仮名 (カタカナのみ) のテキストを取得
             ## ひらがなの方がまだ抑揚の棒読み度がマシになるため、カタカナをひらがなに変換した上で句点を付ける
             flatten_moras = to_flatten_moras(query.accent_phrases)
-            text = "".join([mora.text for mora in flatten_moras]) + "。"
+            text = "".join([mora.text for mora in flatten_moras])
             text = jaconv.kata2hira(text)
-            ## この時点で text が句点だけの場合は空文字列にする
-            if text == "。":
-                text = ""
 
         # AudioQuery.accent_phrase をカタカナモーラと音高 (0 or 1) のリストに変換
         kata_tone_list: list[tuple[str, int]] = []


### PR DESCRIPTION
## 内容

Voicevox互換API経由で生成しようとするとAssertionErrorが出るのを修正します。

<details>
<summary>Details</summary>

```
[2024/11/20 19:06:11] ERROR:    Internal Server Error occurred.
Traceback (most recent call last):
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
    raise exc
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
    await app(scope, receive, sender)
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
    raise exc
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
    await app(scope, receive, sender)
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 214, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/starlette/concurrency.py", line 39, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 2441, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 943, in run
    result = context.run(func, *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/voicevox_engine/app/routers/tts_pipeline.py", line 291, in synthesis
    wave = engine.synthesize_wave(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/voicevox_engine/tts_pipeline/style_bert_vits2_tts_engine.py", line 645, in synthesize_wave
    raw_sample_rate, raw_wave = model.infer(
                                ^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/style_bert_vits2/tts_model.py", line 507, in infer
    audio = infer_onnx(
            ^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/style_bert_vits2/models/infer_onnx.py", line 121, in infer_onnx
    bert, ja_bert, en_bert, phones, tones, lang_ids = get_text_onnx(
                                                      ^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/style_bert_vits2/models/infer_onnx.py", line 47, in get_text_onnx
    norm_text, phone, tone, word2ph = clean_text_with_given_phone_tone(
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/style_bert_vits2/nlp/__init__.py", line 194, in clean_text_with_given_phone_tone
    word2ph = adjust_word2ph(word2ph, phone, given_phone)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sevenc7c/voicevox/AivisSpeech-Engine/.venv/lib/python3.11/site-packages/style_bert_vits2/nlp/japanese/g2p.py", line 330, in adjust_word2ph
    assert len(given_phone) == sum(adjusted_word2ph), f"{len(given_phone)} != {sum(adjusted_word2ph)}"  # fmt: skip
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 4 != 5
```

</details>

### 詳細：

同じ「ほげ」で生成した結果、
- AivisSpeech純正エディタ経由だと`text`が`'ほげ'`
- Voicevoxエディタ、Recotte StudioのVoicevox連携経由だと`text`が`'ほげ。'`

となっていることがわかりました。
これにより音素数とアクセントなどの指定の長さに不一致が発生しAssertionErrorが出ていたものと思われます...が、自分自身style-bert-vits2についてよく判っていないので何か間違った修正をしているかもしれません...

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

 <s>（なぜこれで今までテストが通っていたのかは不明です、現在調査中）</s> どうやらテスト中はテスト用のモックエンジンが使われていたからのようです。