### PR TITLE
Fix: 圧縮されていないファイルを解凍しようとしてテストが失敗するのを修正

### DIFF
--- a/voicevox_engine/user_dict/user_dict_manager.py
+++ b/voicevox_engine/user_dict/user_dict_manager.py
@@ -140,8 +140,11 @@ class UserDictionary:
 
             for file_path in default_dict_files:
                 with file_path.open("rb") as f:
-                    with decompressor.stream_reader(f) as reader:
-                        default_dict_content = reader.read().decode("utf-8")
+                    if file_path.suffix == ".zst":
+                        with decompressor.stream_reader(f) as reader:
+                            default_dict_content = reader.read().decode("utf-8")
+                    else:
+                        default_dict_content = f.read().decode("utf-8")
                 if not default_dict_content.endswith("\n"):
                     default_dict_content += "\n"
                 csv_text += default_dict_content


### PR DESCRIPTION
## 内容

pytestが通常の`.csv`ファイルをzstd解凍しようとしてコケていたのを修正します。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）