### PR TITLE
Draft: Style-Bert-VITS2 向け ONNX GGML Plugin EP を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,5 @@ cython_debug/
 .DS_Store
 ._*
 
+benchmark-artifacts/
 *.wav

--- a/README.md
+++ b/README.md
@@ -588,6 +588,10 @@ uv run task update-licenses
 uv run task build
 ```
 
+ONNX GGML Plugin EP runtime の構築・検証手順は
+[onnxruntime-ep-style-bert-vits2-ggml](https://github.com/Myoland/onnxruntime-ep-style-bert-vits2-ggml)
+を参照してください。
+
 ## ライセンス
 
 ベースである VOICEVOX ENGINE のデュアルライセンスのうち、[LGPL-3.0](LICENSE) のみを単独で継承します。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "truststore>=0.10.0,<1.0.0",
   # aivmlib は AIVMX ファイルのメタデータ読み取りに必要
   "aivmlib>=1.2.1,<2.0.0",
+  "onnxruntime-ep-style-bert-vits2-ggml[convert]",
   # AivisSpeech-Engine にはカスタマイズされた Style-Bert-VITS2 と e2k が必要
   "style-bert-vits2",
   "e2k",
@@ -57,6 +58,7 @@ exclude-newer = "1 week"
 [tool.uv.sources]
 style-bert-vits2 = { git = "https://github.com/tsukumijima/Style-Bert-VITS2", rev = "e702147d2f73a72667dac19ddf6acfe0cb4e3679" }
 e2k = { git = "https://github.com/tsukumijima/e2k", rev = "9920754e15d8c96404bef0bd81d424352fb7a48b" }
+onnxruntime-ep-style-bert-vits2-ggml = { git = "https://github.com/Myoland/onnxruntime-ep-style-bert-vits2-ggml", rev = "c2e6862f226415196a7276086bbda4516a8a02d6" }
 
 [dependency-groups]
 build = [
@@ -128,7 +130,7 @@ docstring-code-format = true
 strict = true
 plugins = "numpy.typing.mypy_plugin,pydantic.mypy"
 python_version = "3.11"
-exclude = ["dist"]
+exclude = ["dist", "build"]
 ignore_missing_imports = true
 warn_unreachable = false
 warn_unused_ignores = false

--- a/run.py
+++ b/run.py
@@ -41,6 +41,14 @@ from typing import TextIO, TypeVar
 
 import sentry_sdk
 import uvicorn
+from onnxruntime_ep_style_bert_vits2_ggml import get_ep_name
+from onnxruntime_ep_style_bert_vits2_ggml.engine_integration import (
+    build_engine_execution_provider_config,
+)
+from onnxruntime_ep_style_bert_vits2_ggml.runtime import (
+    BuiltinProvider,
+    default_backend_for_platform,
+)
 from pydantic import TypeAdapter
 
 from voicevox_engine import __version__
@@ -72,6 +80,37 @@ from voicevox_engine.utility.user_agent_utility import collect_runtime_environme
 # ref: https://github.com/VOICEVOX/voicevox_engine/pull/647#issuecomment-1540204653
 _DEFAULT_HOST = "localhost"
 _DEFAULT_PORT = 10101
+_DEFAULT_ONNX_PLUGIN_EP_NAME = get_ep_name()
+_ONNX_PROVIDER_CHOICES = ("auto", "cuda", "directml", "ggml")
+
+
+def parse_key_value_options(raw_options: list[str] | None) -> dict[str, str]:
+    """Parse repeated KEY=VALUE CLI options into a dictionary."""
+
+    parsed_options: dict[str, str] = {}
+    for raw_option in raw_options or []:
+        key, separator, value = raw_option.partition("=")
+        if separator == "" or key == "":
+            raise ValueError(f"Expected KEY=VALUE, got: {raw_option}")
+        parsed_options[key] = value
+    return parsed_options
+
+
+def decide_onnx_provider_from_env(env_name: str) -> str | None:
+    """Read an explicit ONNX provider selection from the environment."""
+
+    env = os.getenv(env_name)
+    if env is None or env == "":
+        return None
+    provider = env.lower()
+    if provider in _ONNX_PROVIDER_CHOICES:
+        return provider
+    msg = (
+        f"Invalid environment variable value: {env_name}={env}. "
+        f"Expected one of: {', '.join(_ONNX_PROVIDER_CHOICES)}"
+    )
+    warnings.warn(msg, stacklevel=1)
+    return None
 
 
 def decide_boolean_from_env(env_name: str) -> bool:
@@ -127,6 +166,7 @@ class Envs:
     host: str | None
     port: int | None
     use_gpu: bool
+    onnx_provider: str | None
 
 
 _env_adapter = TypeAdapter(Envs)
@@ -142,6 +182,7 @@ def read_environment_variables() -> Envs:
         host=os.getenv("VV_HOST"),
         port=decide_port_from_env("VV_PORT"),
         use_gpu=decide_boolean_from_env("VV_USE_GPU"),
+        onnx_provider=decide_onnx_provider_from_env("VV_ONNX_PROVIDER"),
     )
     return _env_adapter.validate_python(asdict(envs))
 
@@ -210,6 +251,16 @@ class _CLIArgs:
     host: str | None
     port: int | None
     use_gpu: bool | None
+    onnx_provider: str | None
+    ggml_model_cache_dir: Path | None
+    ggml_native_library_path: Path | None
+    ggml_tts_server_backend: str
+    ggml_vulkan_device: str | None
+    ggml_vulkan_precision: str
+    onnx_ep_library_path: Path | None
+    onnx_ep_registration_name: str
+    onnx_ep_name: str | None
+    onnx_ep_options: dict[str, str]
     load_all_models: bool
     output_log_utf8: bool
     cors_policy_mode: CorsPolicyMode | None
@@ -254,6 +305,74 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
             "GPUを使って音声合成するか設定します。指定しない場合、代わりに環境変数 VV_USE_GPU の値が使われます。"
             "VV_USE_GPU の値が1の場合はGPUを使用し、0または空文字、値がない場合は使用されません。"
         ),
+    )
+    parser.add_argument(
+        "--onnx_provider",
+        choices=_ONNX_PROVIDER_CHOICES,
+        default=None,
+        help=(
+            "Style-Bert-VITS2 の ONNX 推論で使う provider を指定します。"
+            "auto は既存の --use_gpu に従い、cuda / directml は組み込み Execution Provider を明示的に使い、"
+            "ggml は外部 ONNX Runtime Plugin EP を使います。"
+            "指定しない場合、代わりに環境変数 VV_ONNX_PROVIDER の値が使われます。"
+        ),
+    )
+    parser.add_argument(
+        "--ggml_model_cache_dir",
+        type=Path,
+        default=None,
+        help="ONNX GGML Plugin EP 用に変換した GGUF モデルのキャッシュディレクトリです。",
+    )
+    parser.add_argument(
+        "--ggml_native_library_path",
+        type=Path,
+        default=None,
+        help=(
+            "ONNX GGML Plugin EP が利用する TTS.cpp C API 共有ライブラリのパスです。"
+            "--onnx_provider ggml では必須です。"
+        ),
+    )
+    parser.add_argument(
+        "--ggml_tts_server_backend",
+        choices=("vulkan", "metal", "cpu"),
+        default=default_backend_for_platform(sys.platform),
+        help="ONNX GGML Plugin EP 内の TTS.cpp backend を指定します。",
+    )
+    parser.add_argument(
+        "--ggml_vulkan_device",
+        default=None,
+        help="Vulkan/Metal backend で利用する device id を provider option として渡します。",
+    )
+    parser.add_argument(
+        "--ggml_vulkan_precision",
+        choices=("accurate", "fast"),
+        default="accurate",
+        help="ONNX GGML Plugin EP の Vulkan precision を指定します。",
+    )
+    parser.add_argument(
+        "--onnx_ep_library_path",
+        type=Path,
+        default=None,
+        help="ONNX Runtime Plugin EP 共有ライブラリのパスです。省略時はパッケージまたはローカル build から探します。",
+    )
+    parser.add_argument(
+        "--onnx_ep_registration_name",
+        default="style_bert_vits2_onnx_plugin_ep",
+        help="ONNX Runtime Plugin EP library の登録名です。",
+    )
+    parser.add_argument(
+        "--onnx_ep_name",
+        default=None,
+        help=(
+            "優先する ONNX Runtime Plugin EP 名です。省略時は "
+            f"{_DEFAULT_ONNX_PLUGIN_EP_NAME} を使います。"
+        ),
+    )
+    parser.add_argument(
+        "--onnx_ep_option",
+        action="append",
+        default=[],
+        help="ONNX Runtime Plugin EP に渡す追加オプションです。KEY=VALUE 形式で複数指定できます。",
     )
     # parser.add_argument(
     #     "--voicevox_dir",
@@ -380,6 +499,12 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
     # args_dict["voicelib_dirs"] = args_dict.pop("voicelib_dir")
     # args_dict["runtime_dirs"] = args_dict.pop("runtime_dir")
     args_dict["allow_origins"] = args_dict.pop("allow_origin")
+    try:
+        args_dict["onnx_ep_options"] = parse_key_value_options(
+            args_dict.pop("onnx_ep_option")
+        )
+    except ValueError as ex:
+        parser.error(str(ex))
 
     # --host に 127.0.0.1 が指定されたとき、Windows 上で localhost でアクセスした際に
     # IPv6 でバインドされないことによる接続遅延を防ぐために、代わりに localhost を指定し IPv4 と IPv6 の両方でバインドする
@@ -410,6 +535,17 @@ def main() -> None:
         set_output_log_utf8()
 
     use_gpu = select_first_not_none([args.use_gpu, envs.use_gpu])
+    onnx_provider = (
+        select_first_not_none_or_none([args.onnx_provider, envs.onnx_provider])
+        or "auto"
+    )
+    builtin_onnx_provider: BuiltinProvider | None = None
+    if onnx_provider == "cuda":
+        builtin_onnx_provider = "cuda"
+    elif onnx_provider == "directml":
+        builtin_onnx_provider = "directml"
+    if onnx_provider in {"cuda", "directml", "ggml"}:
+        use_gpu = True
 
     # この PC の動作環境情報を取得
     # 起動時の可能な限り早い段階で実行結果をキャッシュしておくのが重要
@@ -455,10 +591,32 @@ def main() -> None:
             StyleBertVITS2TTSEngine,
         )
 
+        onnx_plugin_ep = None
+        if onnx_provider == "ggml":
+            onnx_plugin_ep = build_engine_execution_provider_config(
+                base_options=args.onnx_ep_options,
+                backend=args.ggml_tts_server_backend,
+                precision=args.ggml_vulkan_precision,
+                tts_cpp_library_path=args.ggml_native_library_path,
+                vulkan_device=args.ggml_vulkan_device,
+                path_base_dir=engine_root(),
+                library_path=args.onnx_ep_library_path,
+                registration_name=args.onnx_ep_registration_name,
+                provider_name=args.onnx_ep_name,
+                strict=True,
+            )
+
         # AivisSpeech Engine 独自の StyleBertVITS2TTSEngine を通常の TTSEngine の代わりに利用
         tts_engines = TTSEngineManager()
         tts_engines.register_engine(
-            StyleBertVITS2TTSEngine(aivm_manager, use_gpu, args.load_all_models),
+            StyleBertVITS2TTSEngine(
+                aivm_manager,
+                use_gpu,
+                args.load_all_models,
+                preferred_onnx_provider=builtin_onnx_provider,
+                onnx_plugin_ep=onnx_plugin_ep,
+                ggml_model_cache_dir=args.ggml_model_cache_dir,
+            ),
             MOCK_CORE_VERSION,
         )
 

--- a/run.spec
+++ b/run.spec
@@ -4,33 +4,43 @@ import sys
 from pathlib import Path
 from shutil import copy2, copytree
 
-from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+from onnxruntime_ep_style_bert_vits2_ggml.pyinstaller import (
+    copy_runtime_bundle_from_env,
+)
+from PyInstaller.utils.hooks import (
+    collect_data_files,
+    collect_dynamic_libs,
+    collect_submodules,
+)
 
 datas = []
-datas += collect_data_files('e2k')
-datas += collect_data_files('pyopenjtalk')
-datas += collect_data_files('style_bert_vits2')
+datas += collect_data_files("e2k")
+datas += collect_data_files("pyopenjtalk")
+datas += collect_data_files("style_bert_vits2")
+datas += collect_data_files("onnxruntime_ep_style_bert_vits2_ggml")
+
+hiddenimports = collect_submodules("onnxruntime_ep_style_bert_vits2_ggml")
 
 # functorch のバイナリを収集
 # ONNX に移行したため不要なはずだが、念のため
-binaries = collect_dynamic_libs('functorch')
+binaries = collect_dynamic_libs("functorch")
 
 # Windows: Intel MKL 関連の DLL を収集
 # これをやらないと PyTorch が CPU 版か CUDA 版かに関わらずクラッシュする…
 # ONNX に移行したため不要なはずだが、念のため
-if sys.platform == 'win32':
-    lib_dir_path = Path(sys.prefix) / 'Library' / 'bin'
+if sys.platform == "win32":
+    lib_dir_path = Path(sys.prefix) / "Library" / "bin"
     if lib_dir_path.exists():
-        mkl_dlls = list(lib_dir_path.glob('*.dll'))
+        mkl_dlls = list(lib_dir_path.glob("*.dll"))
         for dll in mkl_dlls:
-            binaries.append((str(dll), '.'))
+            binaries.append((str(dll), "."))
 
 a = Analysis(
-    ['run.py'],
+    ["run.py"],
     pathex=[],
     binaries=binaries,
     datas=datas,
-    hiddenimports=[],
+    hiddenimports=hiddenimports,
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -38,7 +48,7 @@ a = Analysis(
     noarchive=False,
     module_collection_mode={
         # Style-Bert-VITS2 内部で使われている TorchScript (@torch.jit) による問題を回避するために必要
-        'style_bert_vits2': 'pyz+py',
+        "style_bert_vits2": "pyz+py",
     },
 )
 
@@ -49,7 +59,7 @@ exe = EXE(
     a.scripts,
     [],
     exclude_binaries=True,
-    name='run',
+    name="run",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
@@ -60,7 +70,7 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    contents_directory='engine_internal',  # 実行時に sys._MEIPASS が参照するディレクトリ名
+    contents_directory="engine_internal",  # 実行時に sys._MEIPASS が参照するディレクトリ名
 )
 
 coll = COLLECT(
@@ -70,17 +80,19 @@ coll = COLLECT(
     strip=False,
     upx=True,
     upx_exclude=[],
-    name='run',
+    name="run",
 )
 
 # 実行ファイルのディレクトリに配置するファイルのコピー
-target_dir = Path(DISTPATH) / 'run'
+target_dir = Path(DISTPATH) / "run"
 
 # リソースをコピー
-manifest_file_path = Path('engine_manifest.json')
+manifest_file_path = Path("engine_manifest.json")
 copy2(manifest_file_path, target_dir)
-copytree('resources', target_dir / 'resources')
+copytree("resources", target_dir / "resources")
 
-license_file_path = Path('licenses.json')
+license_file_path = Path("licenses.json")
 if license_file_path.is_file():
     copy2(license_file_path, target_dir)
+
+copy_runtime_bundle_from_env(target_dir)

--- a/test/unit/test_run_onnx_provider.py
+++ b/test/unit/test_run_onnx_provider.py
@@ -1,0 +1,38 @@
+"""run.py ONNX GGML provider option tests."""
+
+import pytest
+
+from run import decide_onnx_provider_from_env
+
+
+def test_decide_onnx_provider_from_env_accepts_ggml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """VV_ONNX_PROVIDER can explicitly select the ggml Plugin EP route."""
+
+    monkeypatch.setenv("VV_ONNX_PROVIDER", "ggml")
+
+    assert decide_onnx_provider_from_env("VV_ONNX_PROVIDER") == "ggml"
+
+
+@pytest.mark.parametrize("provider", ["cuda", "directml"])
+def test_decide_onnx_provider_from_env_accepts_builtin_gpu_providers(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+) -> None:
+    """VV_ONNX_PROVIDER can explicitly select built-in GPU providers."""
+
+    monkeypatch.setenv("VV_ONNX_PROVIDER", provider)
+
+    assert decide_onnx_provider_from_env("VV_ONNX_PROVIDER") == provider
+
+
+def test_decide_onnx_provider_from_env_rejects_unknown_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown ONNX provider names are ignored with a warning."""
+
+    monkeypatch.setenv("VV_ONNX_PROVIDER", "tensorrt")
+
+    with pytest.warns(UserWarning, match="Expected one of"):
+        assert decide_onnx_provider_from_env("VV_ONNX_PROVIDER") is None

--- a/test/unit/tts_pipeline/test_style_bert_vits2_tts_engine.py
+++ b/test/unit/tts_pipeline/test_style_bert_vits2_tts_engine.py
@@ -18,6 +18,7 @@ from numpy.typing import NDArray
 from style_bert_vits2.constants import DEFAULT_SDP_RATIO, DEFAULT_STYLE_WEIGHT
 
 from voicevox_engine.aivm_manager import AivmManager
+from voicevox_engine.core.core_adapter import DeviceSupport
 from voicevox_engine.metas.metas import StyleId
 from voicevox_engine.model import AudioQuery
 from voicevox_engine.tts_pipeline.model import AccentPhrase, Mora
@@ -215,6 +216,23 @@ def _synthesize_and_get_infer_kwargs(
 
     assert recording_tts_model.infer_kwargs is not None
     return recording_tts_model.infer_kwargs
+
+
+def test_supported_devices_does_not_report_onnx_plugin_ep_as_directml() -> None:
+    engine = object.__new__(StyleBertVITS2TTSEngine)
+    engine.available_onnx_providers = ["CPUExecutionProvider"]
+
+    assert engine.supported_devices == DeviceSupport(cpu=True, cuda=False, dml=False)
+
+
+def test_supported_devices_ignores_unselected_onnx_plugin_ep() -> None:
+    engine = object.__new__(StyleBertVITS2TTSEngine)
+    engine.available_onnx_providers = [
+        "StyleBertVits2GgmlExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+
+    assert engine.supported_devices == DeviceSupport(cpu=True, cuda=False, dml=False)
 
 
 def test_synthesize_wave_uses_trimmed_kana_as_inference_text() -> None:

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -103,6 +103,9 @@ def _update_licenses(pip_licenses: list[_PipLicense]) -> list[_License]:
         "sudachipy": "https://raw.githubusercontent.com/WorksApplications/sudachi.rs/v0.6.8/LICENSE",
         "tokenizers": "https://raw.githubusercontent.com/huggingface/tokenizers/v0.19.1/LICENSE",
     }
+    package_to_license_path: dict[str, str] = {
+        "onnxruntime-ep-style-bert-vits2-ggml": "LICENSE",
+    }
 
     updated_licenses = []
 
@@ -127,11 +130,16 @@ def _update_licenses(pip_licenses: list[_PipLicense]) -> list[_License]:
 
         # ライセンス文が pip から取得できていない場合、pip 外から補う
         if pip_license.LicenseText == "UNKNOWN":
-            if package_name not in package_to_license_url:
+            if package_name in package_to_license_path:
+                pip_license.LicenseText = Path(
+                    package_to_license_path[package_name]
+                ).read_text(encoding="utf-8")
+            elif package_name in package_to_license_url:
+                text_url = package_to_license_url[package_name]
+                pip_license.LicenseText = _get_license_text(text_url)
+            else:
                 # ライセンスが PyPI に存在しない
                 raise Exception(f"No License info provided for {package_name}")
-            text_url = package_to_license_url[package_name]
-            pip_license.LicenseText = _get_license_text(text_url)
 
         updated_licenses.append(
             _License(

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-26T14:59:55.471709192Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -28,6 +28,7 @@ dependencies = [
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'linux')" },
     { name = "onnxruntime-directml", marker = "sys_platform == 'win32'" },
+    { name = "onnxruntime-ep-style-bert-vits2-ggml", extra = ["convert"] },
     { name = "onnxruntime-gpu", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "platformdirs" },
     { name = "psutil" },
@@ -86,6 +87,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "(platform_machine != 'x86_64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'linux')", specifier = ">=1.24.0,<2.0.0" },
     { name = "onnxruntime", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "==1.23.2" },
     { name = "onnxruntime-directml", marker = "sys_platform == 'win32'", specifier = ">=1.24.0,<2.0.0" },
+    { name = "onnxruntime-ep-style-bert-vits2-ggml", extras = ["convert"], git = "https://github.com/Myoland/onnxruntime-ep-style-bert-vits2-ggml?rev=c2e6862f226415196a7276086bbda4516a8a02d6" },
     { name = "onnxruntime-gpu", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=1.24.0,<1.27.0" },
     { name = "platformdirs", specifier = ">=4.2.0" },
     { name = "psutil", specifier = ">=6.1.1" },
@@ -510,6 +512,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/22/2c7acbe6164ed6cfd4301e9ad2dbde69c68d22268a0f9b5b0ee6052ed3ab/g2p_en-2.1.0.tar.gz", hash = "sha256:32ecb119827a3b10ea8c1197276f4ea4f44070ae56cbbd01f0f261875f556a58", size = 3116166, upload-time = "2019-12-31T01:16:12.753Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/d9/b77dc634a7a0c0c97716ba97dd0a28cbfa6267c96f359c4f27ed71cbd284/g2p_en-2.1.0-py3-none-any.whl", hash = "sha256:2a7aabf1fc7f270fcc3349881407988c9245173c2413debbe5432f4a4f31319f", size = 3117464, upload-time = "2019-12-31T01:16:03.286Z" },
+]
+
+[[package]]
+name = "gguf"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/ae/17f1308ae45cd7b08ebb521747d5b23f4efc4d172038a4e228dd5106c3ff/gguf-0.19.0.tar.gz", hash = "sha256:dbadcd6cc7ccd44256f2229fe7c2dff5e8aa5cf0612ab987fd2b1a57e428923f", size = 111220, upload-time = "2026-05-06T13:04:03.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/bb/d71d6da82763528c2c2ed6b59a9d6142c6595545a4c448e2085d155e88c2/gguf-0.19.0-py3-none-any.whl", hash = "sha256:70bcd10edfe697fb2dad6e40af2234b9d8ece9a41a99761405121ebda1c3c1cd", size = 118475, upload-time = "2026-05-06T13:04:02.588Z" },
 ]
 
 [[package]]
@@ -1044,6 +1061,21 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/90/99566dc6398028e7691a5b12720fd85f757a0901818b84599d28abb3f085/onnxruntime_directml-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:96642a787e5a6f33bf043521c0f06eb1eb663f6b830e5862a2026d03f9c90543", size = 25106000, upload-time = "2026-03-17T21:47:15.438Z" },
+]
+
+[[package]]
+name = "onnxruntime-ep-style-bert-vits2-ggml"
+version = "0.1.0"
+source = { git = "https://github.com/Myoland/onnxruntime-ep-style-bert-vits2-ggml?rev=c2e6862f226415196a7276086bbda4516a8a02d6#c2e6862f226415196a7276086bbda4516a8a02d6" }
+
+[package.optional-dependencies]
+convert = [
+    { name = "aivmlib" },
+    { name = "gguf" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "safetensors" },
 ]
 
 [[package]]

--- a/voicevox_engine/tts_pipeline/style_bert_vits2_tts_engine.py
+++ b/voicevox_engine/tts_pipeline/style_bert_vits2_tts_engine.py
@@ -15,8 +15,23 @@ import jaconv
 import numpy as np
 import onnxruntime
 from fastapi import HTTPException
+from huggingface_hub import hf_hub_download
 from numpy.typing import NDArray
 from onnxruntime.capi.onnxruntime_pybind11_state import InvalidProtobuf, NoSuchFile
+from onnxruntime_ep_style_bert_vits2_ggml.engine_integration import (
+    StyleBertVits2GgmlRuntime,
+    resolve_aivmx_onnx_source_path,
+    validate_session_provider,
+)
+from onnxruntime_ep_style_bert_vits2_ggml.runtime import (
+    BuiltinProvider as BuiltinOnnxProvider,
+)
+from onnxruntime_ep_style_bert_vits2_ggml.runtime import (
+    PluginExecutionProviderConfig as OnnxPluginExecutionProviderConfig,
+)
+from onnxruntime_ep_style_bert_vits2_ggml.runtime import (
+    select_builtin_execution_providers,
+)
 from style_bert_vits2.constants import (
     DEFAULT_SDP_RATIO,
     DEFAULT_STYLE_WEIGHT,
@@ -72,10 +87,20 @@ class StyleBertVITS2TTSEngine(TTSEngine):
         use_gpu: bool = False,
         load_all_models: bool = False,
         bert_model_cache_dir: Path | None = None,
+        preferred_onnx_provider: BuiltinOnnxProvider | None = None,
+        onnx_plugin_ep: OnnxPluginExecutionProviderConfig | None = None,
+        ggml_model_cache_dir: Path | None = None,
+        ggml_synthesis_converter_version: str | None = None,
     ) -> None:
         self.aivm_manager = aivm_manager
         self.use_gpu = use_gpu
         self.load_all_models = load_all_models
+        self._onnx_plugin_runtime = StyleBertVits2GgmlRuntime.create(
+            config=onnx_plugin_ep,
+            cache_dir=ggml_model_cache_dir,
+            default_cache_dir=get_save_dir() / "GgufModelCaches",
+            synthesis_converter_version=ggml_synthesis_converter_version,
+        )
 
         # BERT モデルのキャッシュディレクトリ
         self._bert_model_cache_dir = (
@@ -100,57 +125,22 @@ class StyleBertVITS2TTSEngine(TTSEngine):
         ## ref: https://github.com/microsoft/onnxruntime/issues/11627#issuecomment-1137668551
         ## ref: https://skottmckay.github.io/onnxruntime/docs/reference/api/c-api.html
         self.available_onnx_providers: list[str] = onnxruntime.get_available_providers()
-        self.onnx_providers: Sequence[str | tuple[str, dict[str, Any]]] = [
-            ("CPUExecutionProvider", {
-                "arena_extend_strategy": "kSameAsRequested",
-            }),
-        ]  # fmt: skip
-
-        # NVIDIA GPU が接続されていて CUDA がインストールされていれば、CUDAExecutionProvider が利用できる
-        ## DirectML よりも CUDA の方が推論速度が速いため、優先的に利用する
-        ## Windows では若干速度は落ちるが onnxruntime-directml で代用できるのとファイルサイズが 700MB 以上あるため、
-        ## onnxruntime-gpu は既定でインストールされない (Windows で CUDA 推論したいなら各自でインストールが必要)
-        ## Windows / Linux 共に NVIDIA GPU が必要な上に CUDA 自体のサイズが巨大なため、CUDA 自体は同梱していない
-        if use_gpu is True and "CUDAExecutionProvider" in self.available_onnx_providers:
-            self.onnx_providers = []
-            # cudnn_conv_algo_search を DEFAULT にすると推論速度が大幅に向上する
-            # ref: https://medium.com/neuml/debug-onnx-gpu-performance-c9290fe07459
-            self.onnx_providers.append(("CUDAExecutionProvider", {
-                "arena_extend_strategy": "kSameAsRequested",
-                "cudnn_conv_algo_search": "DEFAULT",
-            }))  # fmt: skip
-            # DirectML が利用可能なら、フォールバックとして DmlExecutionProvider も指定する
-            if "DmlExecutionProvider" in self.available_onnx_providers:
-                self.onnx_providers.append(("DmlExecutionProvider", {
-                    "device_id": 0,
-                }))  # fmt: skip
-            # フォールバックとして CPUExecutionProvider も指定する
-            self.onnx_providers.append(("CPUExecutionProvider", {
-                "arena_extend_strategy": "kSameAsRequested",
-            }))  # fmt: skip
-            logger.info("Using GPU (NVIDIA CUDA) for inference.")
-
-        # Windows なら DirectML (DmlExecutionProvider) を利用できる
-        ## iGPU でも利用できるが、大半のケースで CPU 推論よりも大幅に遅くなる
-        elif use_gpu is True and "DmlExecutionProvider" in self.available_onnx_providers:  # fmt: skip
-            self.onnx_providers = []
-            ## TODO: より適した Direct3D 上のデバイス ID を指定できるようにする
-            self.onnx_providers.append(("DmlExecutionProvider", {
-                "device_id": 0,
-            }))  # fmt: skip
-            # フォールバックとして CPUExecutionProvider も指定する
-            self.onnx_providers.append(("CPUExecutionProvider", {
-                "arena_extend_strategy": "kSameAsRequested",
-            }))  # fmt: skip
-            logger.info("Using GPU (DirectML) for inference.")
-
-        # GPU モードが指定されているが GPU が利用できない場合は CPU にフォールバック
-        elif use_gpu is True:
-            logger.warning("GPU is not available. Using CPU instead.")
-
-        # CPU モード指定時
-        else:
-            logger.info("Using CPU for inference.")
+        self.onnx_providers = select_builtin_execution_providers(
+            use_gpu=use_gpu,
+            available_providers=self.available_onnx_providers,
+            preferred_provider=preferred_onnx_provider,
+            logger=logger,
+        )
+        self.onnx_providers = self._onnx_plugin_runtime.configure_providers(
+            base_providers=self.onnx_providers,
+            logger=logger,
+        )
+        self.available_onnx_providers = onnxruntime.get_available_providers()
+        if onnx_plugin_ep is not None:
+            self.onnx_providers = self._onnx_plugin_runtime.prepare_jp_bert_providers(
+                providers=self.onnx_providers,
+                resolve_jp_bert_onnx_path=self._resolve_jp_bert_onnx_path,
+            )
 
         # Style-Bert-VITS2 本体のロガーを抑制
         style_bert_vits2_logger.remove()
@@ -176,7 +166,7 @@ class StyleBertVITS2TTSEngine(TTSEngine):
         start_time = time.time()
         logger.info("Loading BERT model and tokenizer...")
         try:
-            self._load_bert_model_and_tokenizer()
+            bert_session = self._load_bert_model_and_tokenizer()
         except (NoSuchFile, InvalidProtobuf, OSError) as ex:
             # もし BERT モデルキャッシュが破損している、正常にダウンロードできていない、または
             # ネットワークエラーにより不完全にダウンロードされた場合、一度キャッシュを全て削除してから再ダウンロードを試みる
@@ -188,13 +178,20 @@ class StyleBertVITS2TTSEngine(TTSEngine):
             )
             self._reset_bert_model_cache()
             try:
-                self._load_bert_model_and_tokenizer()
+                bert_session = self._load_bert_model_and_tokenizer()
             except (NoSuchFile, InvalidProtobuf, OSError) as ex:
                 logger.error(
                     "Failed to load BERT model and tokenizer after cache reset.",
                     exc_info=ex,
                 )
                 raise ex
+        validate_session_provider(
+            session=bert_session,
+            required_provider_name=self._onnx_plugin_runtime.strict_provider_name(
+                "jp_bert"
+            ),
+            context="JP-BERT ONNX session",
+        )
         logger.info(
             f"BERT model and tokenizer loaded. ({time.time() - start_time:.2f}s)"
         )
@@ -210,20 +207,64 @@ class StyleBertVITS2TTSEngine(TTSEngine):
         ## 継承元の TTSEngine は self._core に CoreWrapper を入れた CoreAdapter のインスタンスがないと動作しない
         self._core = CoreAdapter(MockCoreWrapper())
 
-    def _load_bert_model_and_tokenizer(self) -> None:
+    def _resolve_jp_bert_onnx_path(self) -> Path:
+        """Resolve the JP-BERT ONNX file and required GGUF metadata files."""
+
+        model_path: Path | None = None
+        for filename in ("model_fp16.onnx", "config.json", "vocab.txt"):
+            resolved_path = hf_hub_download(
+                repo_id=self.BERT_MODEL_REPOSITORY,
+                filename=filename,
+                cache_dir=str(self._bert_model_cache_dir),
+                revision=self.BERT_MODEL_REVISION,
+            )
+            if filename == "model_fp16.onnx":
+                model_path = Path(resolved_path)
+        try:
+            hf_hub_download(
+                repo_id=self.BERT_MODEL_REPOSITORY,
+                filename="tokenizer_config.json",
+                cache_dir=str(self._bert_model_cache_dir),
+                revision=self.BERT_MODEL_REVISION,
+            )
+        except Exception:
+            logger.debug("JP-BERT tokenizer_config.json was not downloaded.")
+        assert model_path is not None
+        return model_path
+
+    def _load_bert_model_and_tokenizer(self) -> Any:
         """BERT モデルとトークナイザーをロードし、ローカルキャッシュを更新する。"""
-        onnx_bert_models.load_model(
-            language=Languages.JP,
-            pretrained_model_name_or_path=self.BERT_MODEL_REPOSITORY,
-            onnx_providers=self.onnx_providers,
-            cache_dir=str(self._bert_model_cache_dir),
-            revision=self.BERT_MODEL_REVISION,
+        with self._onnx_plugin_runtime.inference_session_scope():
+            bert_session = onnx_bert_models.load_model(
+                language=Languages.JP,
+                pretrained_model_name_or_path=self.BERT_MODEL_REPOSITORY,
+                onnx_providers=self.onnx_providers,
+                cache_dir=str(self._bert_model_cache_dir),
+                revision=self.BERT_MODEL_REVISION,
+            )
+        self._log_session_providers(
+            session=bert_session,
+            context="JP-BERT",
         )
         onnx_bert_models.load_tokenizer(
             language=Languages.JP,
             pretrained_model_name_or_path=self.BERT_MODEL_REPOSITORY,
             cache_dir=str(self._bert_model_cache_dir),
             revision=self.BERT_MODEL_REVISION,
+        )
+        return bert_session
+
+    @staticmethod
+    def _log_session_providers(*, session: Any, context: str) -> None:
+        """Log the actual ONNX Runtime providers selected for a loaded session."""
+
+        get_providers = getattr(session, "get_providers", None)
+        if not callable(get_providers):
+            return
+        logger.info(
+            "%s ONNX Runtime providers: %s",
+            context,
+            list(get_providers()),
         )
 
     def _reset_bert_model_cache(self) -> None:
@@ -291,12 +332,16 @@ class StyleBertVITS2TTSEngine(TTSEngine):
 
         # AIVM メタデータを読み込む
         aivm_info = self.aivm_manager.get_aivm_info(aivm_model_uuid)
+        onnx_source_path = resolve_aivmx_onnx_source_path(
+            installed_file_path=aivm_info.file_path,
+            aivm_model_uuid=aivm_model_uuid,
+        )
         try:
-            with open(aivm_info.file_path, mode="rb") as f:
+            with open(onnx_source_path, mode="rb") as f:
                 aivm_metadata = aivmlib.read_aivmx_metadata(f)
         except aivmlib.AivmValidationError as ex:
             logger.error(
-                f"{aivm_info.file_path}: Failed to read AIVM metadata:", exc_info=ex
+                f"{onnx_source_path}: Failed to read AIVM metadata:", exc_info=ex
             )
             raise HTTPException(
                 status_code=500,
@@ -311,21 +356,38 @@ class StyleBertVITS2TTSEngine(TTSEngine):
         # スタイルベクトルを読み込む
         assert aivm_metadata.style_vectors is not None
         style_vectors = np.load(BytesIO(aivm_metadata.style_vectors))
+        onnx_providers = self._model_specific_onnx_providers(
+            onnx_source_path=onnx_source_path,
+            aivm_metadata=aivm_metadata,
+        )
 
         # 音声合成モデルをロード
         tts_model = TTSModel(
             # 音声合成モデルのパスとして、AIVMX ファイル (ONNX 互換) のパスを指定
-            model_path=aivm_info.file_path,
+            model_path=onnx_source_path,
             # config_path とあるが、HyperParameters の Pydantic モデルを直接指定できる
             config_path=hyper_parameters,
             # style_vec_path とあるが、style_vectors の NDArray を直接指定できる
             style_vec_path=style_vectors,
             # ONNX 推論で利用する ExecutionProvider を指定
-            onnx_providers=self.onnx_providers,
+            onnx_providers=onnx_providers,
         )  # fmt: skip
         start_time = time.time()
         logger.info(f"Loading {aivm_info.manifest.name} ({aivm_model_uuid}) ...")
-        tts_model.load()
+        with self._onnx_plugin_runtime.inference_session_scope():
+            tts_model.load()
+        if tts_model.onnx_session is not None:
+            self._log_session_providers(
+                session=tts_model.onnx_session,
+                context=aivm_info.manifest.name,
+            )
+        validate_session_provider(
+            session=tts_model.onnx_session,
+            required_provider_name=self._onnx_plugin_runtime.strict_provider_name(
+                "synthesis"
+            ),
+            context="synthesis ONNX session",
+        )
         with self._tts_models_lock:
             # ロード中に別スレッドが同一モデルを先にロードした場合は、そのインスタンスを優先して利用する
             if aivm_model_uuid in self.tts_models:
@@ -340,6 +402,32 @@ class StyleBertVITS2TTSEngine(TTSEngine):
         )
 
         return tts_model
+
+    def _model_specific_onnx_providers(
+        self,
+        *,
+        onnx_source_path: Path,
+        aivm_metadata: Any,
+    ) -> Sequence[str | tuple[str, dict[str, Any]]]:
+        if self._onnx_plugin_runtime.config is None:
+            return self.onnx_providers
+        try:
+            return self._onnx_plugin_runtime.prepare_synthesis_providers(
+                providers=self.onnx_providers,
+                onnx_source_path=onnx_source_path,
+                aivm_metadata=aivm_metadata,
+                resolve_jp_bert_onnx_path=self._resolve_jp_bert_onnx_path,
+            )
+        except Exception as ex:
+            logger.error(
+                "%s: Failed to prepare ONNX Plugin EP GGUF cache.",
+                onnx_source_path,
+                exc_info=ex,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to prepare ONNX Plugin EP GGUF cache.",
+            ) from ex
 
     def unload_model(self, aivm_model_uuid: str) -> None:
         """


### PR DESCRIPTION
## Summary

Style-Bert-VITS2 の ONNX 推論に opt-in の GGML/TTS.cpp backend を追加し、CUDA 非搭載環境でも Metal / Vulkan 経由で高速に動作できる `--onnx_provider ggml` 経路を導入します。既定の `auto` / CPU / CUDA / DirectML 経路は変更しません。

## What Changed

- `--onnx_provider ggml` と `VV_ONNX_PROVIDER=ggml` を追加しました。
- GGML 経路を選んだ場合だけ、外部 ONNX Runtime Plugin EP を登録します。
- synthesis model は ONNX session 作成前に GGUF cache へ変換します。
- JP-BERT は F16 `linear` GGUF を既定にし、メモリ使用量を抑えます。
- Plugin EP が実際に使われていることを session provider で検証します。
- PyInstaller package では runtime bundle を環境変数から取り込めるようにしました。

Engine 側の変更は主に以下です。

- `run.py`: provider 選択、GGML/Plugin EP option の CLI/env wiring
- `voicevox_engine/tts_pipeline/style_bert_vits2_tts_engine.py`: provider selection、GGUF cache preparation、session provider validation
- `run.spec`: runtime package data と native bundle の取り込み
- `test/unit/test_run_onnx_provider.py`
- `test/unit/tts_pipeline/test_style_bert_vits2_tts_engine.py`

native runtime / GGUF 変換 / benchmark script は Engine から分離し、以下の repository に置いています。

- Runtime package: https://github.com/Myoland/onnxruntime-ep-style-bert-vits2-ggml
- TTS.cpp fork: https://github.com/Myoland/TTS.cpp
- ggml fork: https://github.com/Myoland/ggml

## Scope

この PR は Draft です。まず、AivisSpeech Engine に GGML backend を opt-in で統合する方向性が受け入れ可能か確認したいです。

この PR では以下を対象外にしています。

- 既定 backend の変更
- native runtime の同梱方式の最終決定
- benchmark artifact / GGUF cache / audio file の repository への追加
- Android / mobile support

## Reproduction

### 1. Engine の unit test

```bash
uv run --frozen pytest \
  test/unit/test_run_onnx_provider.py \
  test/unit/tts_pipeline/test_style_bert_vits2_tts_engine.py \
  -q
```

### 2. Runtime bundle build

```bash
PLUGIN_REPO_DIR=<onnxruntime-ep-style-bert-vits2-ggml checkout>

cd "$PLUGIN_REPO_DIR"
./build.sh
```

macOS / Linux では `./build.sh`、Windows では `./build.ps1` または `build.bat` を使います。詳細は runtime repository の build document を参照してください。

### 3. macOS benchmark example

```bash
ENGINE_DIR=<AivisSpeech-Engine checkout>
PLUGIN_REPO_DIR=<onnxruntime-ep-style-bert-vits2-ggml checkout>
PLUGIN_BUNDLE_DIR="$PLUGIN_REPO_DIR/dist/style-bert-vits2-ggml-runtime-macos-arm64"

cd "$ENGINE_DIR"
uv run --frozen python "$PLUGIN_REPO_DIR/scripts/reproduce_onnx_ggml_benchmark.py" \
  --engine-dir "$ENGINE_DIR" \
  --ggml-native-library-path "$PLUGIN_BUNDLE_DIR/lib/libtts.dylib" \
  --onnx-ep-library-path "$PLUGIN_BUNDLE_DIR/onnxruntime_ep_style_bert_vits2_ggml/lib/libstyle_bert_vits2_ggml_onnx_ep.dylib" \
  --library-dir "$PLUGIN_BUNDLE_DIR/lib"
```

この script は AivisHub model を download し、SHA-256 を検証し、provider evidence / RTF / PCM comparison / audio sample を `benchmark-artifacts/` 以下に生成します。

## Benchmark

Benchmark model:

| item | value |
| --- | --- |
| model | `まお` |
| source | https://hub.aivis-project.com/aivm-models/a59cb814-0083-4369-8542-f51a29e72af7 |
| version | `1.2.0` |
| style id | `888753760` |
| SHA-256 | `f87ccea2e8e2de0e0bfe52e803945af903b4086bf25621a015111628f00e4119` |

Default GGML profile:

| item | value |
| --- | --- |
| synthesis GGUF | FP32 |
| JP-BERT GGUF | F16 `linear` |
| backend | Metal on macOS, Vulkan on Linux/Windows |
| validation | `StyleBertVits2GgmlExecutionProvider` が session provider に含まれることを確認 |

Representative RTF:

| device | backend | synthesis GGUF | JP-BERT GGUF | short | medium | long |
| --- | --- | --- | --- | ---: | ---: | ---: |
| Linux RTX 3060 | GGML Vulkan | FP32 | F16 `linear` | `0.130` | `0.094` | `0.063` |
| Windows Arc B580 | GGML Vulkan | FP32 | F16 `linear` | `0.108` | `0.091` | `0.056` |
| macOS M1 Pro | GGML Metal | FP32 | F16 `linear` | `0.185` | `0.147` | `0.128` |
| Linux Radeon 780M | GGML Vulkan | FP32 | F16 `linear` | `0.163` | `0.135` | `0.108` |

JP-BERT F16 `linear` は FP32 JP-BERT と比較して約 46% 小さく、deterministic comparison では sample count が一致し、相関も `0.9998` 前後を維持しました。そのため、この PR では synthesis は保守的に FP32、JP-BERT は F16 `linear` を既定の実用 profile としています。

## Notes for Reviewers

- `--onnx_provider ggml` を指定しない限り、Plugin EP は登録されません。
- GGML 経路では strict mode で provider を検証するため、CPU fallback を GGML 結果として扱わないようにしています。
- native runtime の repository / 配布形態 / Aivis Project 側への移管可否は、この Draft PR の discussion で相談したいです。
